### PR TITLE
SRA-10240

### DIFF
--- a/tools/tax/src/aligns_to.cpp
+++ b/tools/tax/src/aligns_to.cpp
@@ -55,7 +55,7 @@ int main(int argc, char const *argv[])
     #endif
     
     LOG("aligns_to version " << VERSION);
-    LOG("hardware threads: "  << std::thread::hardware_concurrency() << ", omp threads: " << omp_get_max_threads());
+    LOG("hardware threads: "  << std::thread::hardware_concurrency() << ", omp threads: " << omp_get_num_threads());
     Config config(argc, argv);
     if (config.num_threads > 0)
         omp_set_num_threads(config.num_threads);


### PR DESCRIPTION
As seen in the compare, the change is cosmetic to make reporting the number of threads used accurate.  As the code is being used more widely I think this is wise to finally correct.