### PR TITLE
SRAB-1164, update quickbuild.sh for aligns_to dependencies

### DIFF
--- a/tools/tax/README.md
+++ b/tools/tax/README.md
@@ -10,4 +10,4 @@ ngs-tools::Sequence Taxonomic Analysis Tool (STAT)
 * ### Read build_db_and_run.sh: it is richly annotated with comments about each step performed.
   * (NOTE: requires python3 for successful script execution.)
 
-* ### If you need NGS library support, or want all the tools you can run ./build.sh from any folder. 
+* ### If want all the tools you can run ./build.sh from any folder. 

--- a/tools/tax/quickbuild.sh
+++ b/tools/tax/quickbuild.sh
@@ -1,5 +1,16 @@
 set -e
-g++ -std=c++17 -O3 -fopenmp -I./src/ ./src/aligns_to.cpp ./src/reader.cpp -o ./bin/aligns_to -Wreturn-type -msse4.2 -DBMSSE42OPT -lpthread -ldl -pthread
+
+trap cleanup EXIT ERR INT
+
+cleanup(){
+if [ "$(ls -A ${TmpD})" ]
+  then rm -rf  "${TmpD}"
+fi
+}
+
+TmpD=$(mktemp -d)
+git clone https://github.com/ncbi/sra-tools.git $TmpD/sra-tools
+g++ -std=c++17 -O3 -fopenmp -I./src/ -I $TmpD/sra-tools/libs/inc   ./src/aligns_to.cpp ./src/reader.cpp -o ./bin/aligns_to -Wreturn-type -msse4.2 -DBMSSE42OPT -lpthread -ldl -pthread
 g++ -std=c++11 -O3 -fopenmp ./src/build_index_of_each_file.cpp -o ./bin/build_index_of_each_file -Wreturn-type
 g++ -std=c++11 -O3 -fopenmp ./src/merge_db.cpp -o ./bin/merge_db -Wreturn-type
 g++ -std=c++11 -O3 -fopenmp ./src/identify_tax_ids.cpp -o ./bin/identify_tax_ids -Wreturn-type


### PR DESCRIPTION
Simple change to quickbuild.sh by making local header lib path from sra-tools for dependent header libraries.